### PR TITLE
Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+#FROM golang:1.11.5-stretch
+FROM iotex/iotex-core:v0.5.1
+
+# Install project
+WORKDIR $GOPATH/src/github.com/Infinity-Stones/iotex_payout
+COPY . .
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh && \
+	dep ensure && \
+	go build && \
+    chmod 755 iotex_payout && \
+    cp $GOPATH/src/github.com/Infinity-Stones/iotex_payout/iotex_payout /usr/local/bin/iotex_payout && \
+    ioctl config set endpoint api.iotex.one:80 --insecure

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ iotex_payout [arguments]
 ```
 
 
-### Run iotex payout
+### Run under Docker
 Build the container
 ```
 docker build -f Dockerfile . -t iotexpayout

--- a/README.md
+++ b/README.md
@@ -51,3 +51,13 @@ Run the container interactively
 docker run -ti iotexpayout bash
 ```
 
+Use ioctl to setup operator account
+```
+ioctl account import operator
+```
+
+Run iotex_payout 
+```
+iotex_payout delegate operator -e 100 -b 95 -p 90 -f 80
+```
+

--- a/README.md
+++ b/README.md
@@ -38,3 +38,16 @@ go build
 ```
 iotex_payout [arguments]
 ```
+
+
+### Run iotex payout
+Build the container
+```
+docker build -f Dockerfile . -t iotexpayout
+```
+
+Run the container interactively
+```
+docker run -ti iotexpayout bash
+```
+


### PR DESCRIPTION
Docker build for iotex_payout leveraging the iotex core container , need to add persistent storage in future using docker-compose for ioctl if you are using alias.